### PR TITLE
Refactor/dependency inversion

### DIFF
--- a/backend/src/main/kotlin/com/example/backend/CleanArchitectureApplication.kt
+++ b/backend/src/main/kotlin/com/example/backend/CleanArchitectureApplication.kt
@@ -1,4 +1,4 @@
-package com.example.clean_architecture
+package com.example.backend
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication

--- a/backend/src/main/kotlin/com/example/backend/controller/TaskController.kt
+++ b/backend/src/main/kotlin/com/example/backend/controller/TaskController.kt
@@ -1,0 +1,36 @@
+package com.example.backend.controller
+
+import com.example.backend.domain.Task
+import com.example.backend.service.TaskService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/tasks")
+class TaskController(
+    private val taskService: TaskService,
+) {
+
+    @PostMapping
+    fun registerTask(
+        @RequestBody request: RegisterTaskRequest,
+    ): ResponseEntity<Task> {
+        val task = taskService.registerTask(request.taskName, request.taskDescription)
+        return ResponseEntity.ok(task)
+    }
+
+    data class RegisterTaskRequest(
+        val taskName: String,
+        val taskDescription: String,
+    )
+
+    @GetMapping
+    fun getTasks(): ResponseEntity<List<Task>> {
+        val tasks = taskService.getTasks()
+        return ResponseEntity.ok(tasks)
+    }
+}

--- a/backend/src/main/kotlin/com/example/backend/domain/Task.kt
+++ b/backend/src/main/kotlin/com/example/backend/domain/Task.kt
@@ -1,0 +1,19 @@
+package com.example.backend.domain
+
+import java.util.UUID
+
+class Task(
+    val id: UUID,
+    val title: String,
+    val description: String,
+) {
+    companion object {
+        fun createTask(taskName: String, taskDescription: String): Task {
+            return Task(
+                id = UUID.randomUUID(),
+                title = taskName,
+                description = taskDescription
+            )
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/example/backend/domain/TaskRepository.kt
+++ b/backend/src/main/kotlin/com/example/backend/domain/TaskRepository.kt
@@ -1,0 +1,6 @@
+package com.example.backend.domain
+
+interface TaskRepository {
+    fun registerTask(task: Task)
+    fun getTasks(): List<Task>
+}

--- a/backend/src/main/kotlin/com/example/backend/infrastracture/TaskRepository.kt
+++ b/backend/src/main/kotlin/com/example/backend/infrastracture/TaskRepository.kt
@@ -1,0 +1,12 @@
+package com.example.backend.infrastracture
+
+import com.example.backend.domain.Task
+import org.springframework.stereotype.Repository
+
+@Repository
+class TaskRepository {
+
+    fun registerTask(task: Task) {
+        // TODO
+    }
+}

--- a/backend/src/main/kotlin/com/example/backend/infrastracture/TaskRepository.kt
+++ b/backend/src/main/kotlin/com/example/backend/infrastracture/TaskRepository.kt
@@ -1,12 +1,20 @@
 package com.example.backend.infrastracture
 
 import com.example.backend.domain.Task
+import com.example.backend.domain.TaskRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-class TaskRepository {
+class TaskRepositoryImpl : TaskRepository {
 
-    fun registerTask(task: Task) {
-        // TODO
+    // FIXME: In-memory storage for tasks
+    private val tasks = mutableListOf<Task>()
+
+    override fun registerTask(task: Task) {
+        tasks.add(task)
+    }
+
+    override fun getTasks(): List<Task> {
+        return tasks
     }
 }

--- a/backend/src/main/kotlin/com/example/backend/service/TaskService.kt
+++ b/backend/src/main/kotlin/com/example/backend/service/TaskService.kt
@@ -1,7 +1,7 @@
 package com.example.backend.service
 
 import com.example.backend.domain.Task
-import com.example.backend.infrastracture.TaskRepository
+import com.example.backend.domain.TaskRepository
 import org.springframework.stereotype.Service
 
 @Service
@@ -10,15 +10,11 @@ class TaskService(
 ) {
     fun registerTask(taskName: String, taskDescription: String): Task {
         val task = Task.createTask(taskName, taskDescription)
+        taskRepository.registerTask(task)
         return task
     }
 
     fun getTasks(): List<Task> {
-        // TODO
-        return listOf(
-            Task.createTask("task1", "description1"),
-            Task.createTask("task2", "description2"),
-            Task.createTask("task3", "description3"),
-        )
+        return taskRepository.getTasks()
     }
 }

--- a/backend/src/main/kotlin/com/example/backend/service/TaskService.kt
+++ b/backend/src/main/kotlin/com/example/backend/service/TaskService.kt
@@ -1,0 +1,24 @@
+package com.example.backend.service
+
+import com.example.backend.domain.Task
+import com.example.backend.infrastracture.TaskRepository
+import org.springframework.stereotype.Service
+
+@Service
+class TaskService(
+    private val taskRepository: TaskRepository,
+) {
+    fun registerTask(taskName: String, taskDescription: String): Task {
+        val task = Task.createTask(taskName, taskDescription)
+        return task
+    }
+
+    fun getTasks(): List<Task> {
+        // TODO
+        return listOf(
+            Task.createTask("task1", "description1"),
+            Task.createTask("task2", "description2"),
+            Task.createTask("task3", "description3"),
+        )
+    }
+}


### PR DESCRIPTION
## Purpose
The domain layer should not depend on the repository implementation.
This pull request refactors the dependency structure so that domain services depend on interfaces defined within the domain layer, rather than concrete implementations.

### before
```mermaid
classDiagram
namespace domain {
  class Task
  class TaskService
}
namespace repository {
  class TaskRepository
}

TaskService --> TaskRepository
```

### after
```mermaid
classDiagram
namespace domain {
  class Task
  class TaskService
  class TaskRepository
}
namespace repository {
  class TaskRepositoryImpl
}

TaskService --> TaskRepository
TaskRepository <|-- TaskRepositoryImpl
```